### PR TITLE
Assurer des liens valides

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: test
 
 on:
   push:
@@ -7,7 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+
+  lint-markdown:
 
     runs-on: ubuntu-latest
 
@@ -21,3 +22,12 @@ jobs:
         run: bundle install
       - name: Run tests (lint markdown)
         run: bundle exec mdl _posts
+
+  lint-markdown-link:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          folder-path: '_posts'

--- a/_posts/2020-04-13-principes-d-architecture-applicative.md
+++ b/_posts/2020-04-13-principes-d-architecture-applicative.md
@@ -18,7 +18,7 @@ L'architecture de Pix est construite autour de 3 propriétés applicatives et le
 ## 1. User Centric Architecture
 
 D'un point de vue architecture Pix a été conçu comme une galaxie avec des planètes, une par usage / typologie d'utilisateurs :
-
+<!-- markdown-link-check-disable -->
 - [Pix.fr](https://pix.fr) pour les utilisateurs invités (i.e. non connectés) ou en quête d'information institutionnelle
 - [Pix App](https://app.pix.fr) pour les utilisateurs connectés qui souhaitent se positionner au sein du référentiel de compétences numériques et se faire certifier
 - [Pix Orga](https://orga.pix.fr) pour les organisations (établissements scolaires ou supérieurs, entreprises, administrations, associations, etc.) qui déploient, coordonnent et/ou prescrivent Pix auprès de populations d'utilisateurs accompagnées (écoliers, étudiants, salariés, etc.)
@@ -26,6 +26,7 @@ D'un point de vue architecture Pix a été conçu comme une galaxie avec des pla
 - [Pix Admin](https://admin.pix.fr) pour les administrateurs de la plateforme : développeurs, jurés, exploitants, etc.
 - [Pix Editor](https://editor.pix.fr) pour les producteurs / réplicateurs de contenu pédagogique (domaines, compétences, épreuves, acquis, tutoriels) qui souhaitent enrichir le référentiel Pix
 - etc.
+<!-- markdown-link-check-enable -->
 
 Le choix d'une plateforme Web (VS. client lourd "à l'ancienne" VS. RDA VS. mobile / native / hybride) a été fait afin de toucher un public le plus large.
 

--- a/_posts/2020-04-13-principes-de-securite.md
+++ b/_posts/2020-04-13-principes-de-securite.md
@@ -40,7 +40,7 @@ Plutôt que de réinventer la roue avec l'illusion d'avoir la nouvelle idée ou 
 
 Ex : les services de l'API implémentent le [protocole AAA](https://fr.wikipedia.org/wiki/Protocole_AAA) : Authentification, Autorisation, Traçabilité.
 
-Ex : l'authentification au sein de la plateforme se base sur le [protocole OAuth 2](https://oauth.net/2/), cf. [RFC 6749](https://tools.ietf.org/html/rfc6749), [RFC 6750](https://tools.ietf.org/html/rfc6750) et [RFC 6819](http://rfc6819/).
+Ex : l'authentification au sein de la plateforme se base sur le [protocole OAuth 2](https://oauth.net/2/), cf. [RFC 6749](https://tools.ietf.org/html/rfc6749), [RFC 6750](https://tools.ietf.org/html/rfc6750) et [RFC 6819](https://tools.ietf.org/html/rfc6819).
 
 Ex : la procédure de gestion et les informations de “session pour un utilisateur connecté" se basent sur le principe et la [technologie JWT](https://fr.wikipedia.org/wiki/JSON_Web_Token), standard actuel pour une exploitation Web sans état (stateless).
 

--- a/_posts/2020-12-23-legacy-code.md
+++ b/_posts/2020-12-23-legacy-code.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Legacy code"
-date: 2020-12-23 15:53:00 +0200
+date: 2021-05-07 09:00:00 +0200
 categories: architecture
 excerpt: Comment changer incrémentalement le design ?
 cover:
@@ -129,7 +129,7 @@ La modification effective fait [64 lignes](https://github.com/1024pix/pix-db-rep
 Le comportement principal de l'application est constitué d'effets de bord en base de données. Nous avons utilisé le framework de
 test habituel (mocha/chai). Plutôt que de reprendre la couche d'accès habituelle aux données de pix
 ([knex](https://github.com/knex/knex) + [node_postgres](https://github.com/brianc/node-postgres)),
-nous sommes passés par le client natif `psql`. Celui-ci est appelé par NodeJS via la librairie [execa]<https://github.com/sindresorhus/exec>).
+nous sommes passés par le client natif `psql`. Celui-ci est appelé par NodeJS via la librairie [execa](https://github.com/sindresorhus/execa).
 
 La [PR](https://github.com/1024pix/pix-db-replication/pull/28/files) obtenue fait 300 lignes.
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,10 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": ".*\/assets\/images\/posts\/.*"
+    },
+    {
+      "pattern": "https://zhuanlan.zhihu.com/p/140799707"
+    }
+  ]
+}


### PR DESCRIPTION
## :unicorn: Problème
Les liens des posts peuvent être invalides, ou le devenir

## :robot: Solution
Utiliser [markdown-link-check](https://github.com/tcort/markdown-link-check), sous la forme d'une [GitHub action](https://github.com/gaurav-nelson/github-action-markdown-link-check)

## :rainbow: Remarques
Ajout en whitelist
- des images
- des liens vers *.px.fr (mystère..)

## :100: Pour tester
Ajouter un lien invalide et vérifier que le check  `lint-markdown-link`  devient rouge
