### PR TITLE
[TECH] Proposer une configuration d'IDE compatible avec le lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/_posts/2022-12-29-whitespace.md
+++ b/_posts/2022-12-29-whitespace.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title:  "Passer une PK de INT en BIGINT en zéro downtime"
+date:   2021-09-03 10:10:42 +0200
+categories: bdd
+excerpt: "Sur une table volumineuse en PostgreSQL"
+cover:
+image: "change-pk-unreferenced-bigint.png"
+source_title: https://richmondlockandkey.com/master-key-systems/
+source_url: https://richmondlockandkey.com/wp-content/uploads/2020/04/unnamed-e1587059843528.png.webp
+authors: pierre_top
+---
+
+## TL;DR
+
+A 
+AA


### PR DESCRIPTION
## :unicorn: Problème
L'étape de lint refuse les espaces de fin de ligne.
Or l'IDE a tendance a les conserver.

## :robot: Solution
Lui suggérer de les retirer avec un fichier .editorconfig.

## :100: Pour tester
Modifier le post de test
