### PR TITLE
Add feed link to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Articles, actualités et aventures techniques des équipes Pix.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://engineering.pix.fr" # the base hostname & protocol for your site, e.g. http://example.com
+rss: "feed"
 #twitter_username: pix_engineering
 github_username: 1024pix
 #paginate: 9


### PR DESCRIPTION
## :unicorn: Problème

Lorsque l'on souhaite s'abonner au blog technix, il faut « inspecter » le code pour trouver l'url du « flux ».

## :robot: Solution

Rendre visible un lien pour le flux déjà disponible.

## :rainbow: Remarques

Le thème minima propose d'utiliser des éléments dans la configuration pour générer le `footer`.

 :warning: Les nouvelles versions du thème modifient la configuration actuellement proposée.

## :100: Pour tester

voir en local... :)
